### PR TITLE
fix: remove ParaLink entries

### DIFF
--- a/packages/xtoken-home/src/app/page.tsx
+++ b/packages/xtoken-home/src/app/page.tsx
@@ -19,7 +19,6 @@ export default function Home() {
           </span>
         </div>
         <div className="flex items-center gap-8">
-          <Card icon="/darwinia.png" link="https://bridge.darwinia.network" label="Darwinia" />
           <Card icon="/docs.png" link="./docs.html" label="Docs" />
         </div>
       </div>

--- a/packages/xtoken-ui/src/components/footer.tsx
+++ b/packages/xtoken-ui/src/components/footer.tsx
@@ -8,14 +8,6 @@ export default function Footer() {
       <div className="hidden items-center gap-5 lg:flex">
         <a
           className="text-xs font-semibold text-white/50 transition hover:text-white active:scale-95"
-          href="https://para.link/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Darwinia Paralink
-        </a>
-        <a
-          className="text-xs font-semibold text-white/50 transition hover:text-white active:scale-95"
           href="https://docs.helixbox.ai/"
           rel="noopener noreferrer"
           target="_blank"

--- a/packages/xtoken-ui/src/components/header.tsx
+++ b/packages/xtoken-ui/src/components/header.tsx
@@ -17,7 +17,6 @@ interface NavigationConfig {
 const navigationsConfig: NavigationConfig[] = [
   { href: "/", label: "Bridge" },
   { href: "/explorer", label: "Explorer" },
-  { href: "https://para.link/", label: "Paralink", external: true },
   { href: "/wrap", label: "Wrap" },
 ];
 


### PR DESCRIPTION
## Summary
- Remove the Darwinia/ParaLink card from xtoken-home.
- Remove explicit para.link navigation/footer entries from xtoken-ui.

## Verification
- yarn build:xtoken-home ✅
- Search confirmed no ParaLink/para.link/bridge.darwinia entries remain in xtoken-home and no ParaLink/para.link entries remain in xtoken-ui source files.
- Independent code review passed ✅
- yarn build:xtoken-ui currently fails on main and this branch with pre-existing TS2550 Array.prototype.at lib-target errors in unrelated files.
- yarn workspace xtoken-ui lint currently fails on main and this branch with pre-existing react-refresh warnings in provider files.

## Notes
- Direct push to helix-bridge/xtoken-monorepo was denied for the current GitHub account (read-only), so this PR is opened from the boundless-forest fork.